### PR TITLE
Fix srim momentum spread

### DIFF
--- a/src/EVA/windows/srim/trim_presenter.py
+++ b/src/EVA/windows/srim/trim_presenter.py
@@ -22,7 +22,7 @@ class TrimPresenter(QWidget):
         self.view = view
         self.model = model
 
-        self.view.sample_name_linedit.setText("Cu")
+        self.view.sample_name_linedit.setText("Sample")
         self.view.momentum_linedit.setText(str(self.model.momentum[0]))
         self.view.momentum_spread_linedit.setText(str(self.model.momentum_spread))
         self.view.min_momentum_linedit.setText(str(self.model.min_momentum))
@@ -237,6 +237,10 @@ class TrimPresenter(QWidget):
         if not srimdir_valid or not outputdir_valid:
             self.view.display_error_message(message="Could not find SRIM.exe at specified location. "
                                      "Please ensure you have SRIM2013 installed.")
+            return
+
+        if form_data["momentum_spread"] and form_data["stats"] < 500:
+            self.view.display_error_message(message="Momentum spread simulation requires a minimum of 500 muons.")
             return
 
         # if everything is ok, send data to model and simulate


### PR DESCRIPTION
Fixing the momentum spread simulations. Previously, the momentum spread simulations were done by calculating a spread of momentum to calculate for, then running each momentum simulation with the same number of ions. However in the original implementation, the momentum spread was calculated using a Gaussian spread of number of ions, so this has been corrected now.