### PR TITLE
Update publish_docs.yml

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser sphinx_autodoc_typehints
+          pip install . sphinx sphinx_rtd_theme myst_parser sphinx_autodoc_typehints
       - name: Sphinx build
         run: |
           sphinx-build doc _build

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,6 +3,11 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 


### PR DESCRIPTION
Autodocs currently not working properly on github pages - there is an issue with importing EVA before building sphinx docs on github actions.