### PR TITLE
Fix modelfit residual logic and plot layout semantics

### DIFF
--- a/src/EVA/core/plot/plotting.py
+++ b/src/EVA/core/plot/plotting.py
@@ -106,8 +106,6 @@ def plot_spectrum_residual(spectrum: Spectrum, normalisation: str, **settings: d
     main_ax.set_ylim(0.0)
     main_ax.set_xlim(0.0)
     main_ax.tick_params(labelbottom=True)
-
-    fig.tight_layout()
     
     return fig, ax
 
@@ -218,4 +216,4 @@ def replot_run(run: Run, fig: plt.Figure, axs: np.ndarray[plt.Axes] | plt.Axes, 
 def replot_run_residual(run: Run, fig: plt.Figure, axs: np.ndarray[plt.Axes] | plt.Axes, **settings: dict):
     replot_run(run, fig, axs[0], **settings)
     fig.supylabel(get_ylabel(run.normalisation))
-    fig.tight_layout()
+  #  fig.tight_layout()

--- a/src/EVA/gui/windows/peakfit/peakfit_model.py
+++ b/src/EVA/gui/windows/peakfit/peakfit_model.py
@@ -225,7 +225,7 @@ class PeakFitModel(QObject):
 
 			self.plot_residual()
 
-			self.fig.tight_layout()
+		#	self.fig.tight_layout()
 
 		# y range for plotting (to make plot look nice)
 		def calculate_y_range(self, ydata: np.ndarray):
@@ -245,13 +245,8 @@ class PeakFitModel(QObject):
 
 				file.close()
 
-
-		def replot_spectrum(self):
-				replot_run(self.run, self.fig, self.axs, colour=get_config()["plot"]["fill_colour"])
-
-
 		def replot_spectrum_residual(self):
-				replot_run_residual(self.run, self.fig, self.axs, colour=get_config()["plot"]["fill_colour"])
+				replot_run_residual(self.run, self.fig, self.axs, self.fit_result, colour=get_config()["plot"]["fill_colour"])
 
 
 		def load_params(self, path: str):


### PR DESCRIPTION
Mirror main and residual axes functionality implemented in peakfit_model.py and remove fig.tight_layout where unneccesary to avoid formatting issues.

Fixes #21 