### PR TITLE
Bug/trim muon number

### DIFF
--- a/G4BL_WINDOW.log
+++ b/G4BL_WINDOW.log
@@ -1,0 +1,4 @@
+2026-04-14 16:59:49,779 INFO: Starting EVA...
+2026-04-14 16:59:49,779 DEBUG: Root directory: C:\Users\chend\Desktop\Projects\eva-clean
+2026-04-14 16:59:49,864 DEBUG: Created thread pool. Maximum thread count: 12
+2026-04-14 16:59:49,906 INFO: Launching main window.

--- a/src/EVA/core/data_loading/load_data.py
+++ b/src/EVA/core/data_loading/load_data.py
@@ -60,8 +60,8 @@ def load_comment_brni(run_num: str, file_path: str) -> tuple[list[str], int]:
 
     """
     try:
-        fd = open(file_path + '/Comment.dat', 'r')
-        #commenttext = open(globals.workingdirectory + '/comment.dat', 'r').readlines()
+        fd = open(file_path + "/Comment.dat", "r")
+        # commenttext = open(globals.workingdirectory + '/comment.dat', 'r').readlines()
         commenttext = fd.readlines()
 
         search_str = "Run " + run_num

--- a/src/EVA/gui/ui_files/trim.ui
+++ b/src/EVA/gui/ui_files/trim.ui
@@ -294,10 +294,17 @@
             </column>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="4" column="0" colspan="2">
            <widget class="QPushButton" name="save_all_sims_button">
             <property name="text">
-             <string>Save all</string>
+             <string>Save all results</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QPushButton" name="save_all_imgs_button">
+            <property name="text">
+             <string>Save all plots</string>
             </property>
            </widget>
           </item>
@@ -456,7 +463,7 @@
       <item>
        <widget class="QTabWidget" name="results_tabs">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="stopping_profiles_tab">
          <attribute name="title">
@@ -552,13 +559,13 @@ QSlider::ticks {color: grey}</string>
   <customwidget>
    <class>PlotWidget</class>
    <extends>QWidget</extends>
-   <header location="global">EVA.widgets.plot.plot_widget</header>
+   <header location="global">EVA.gui.widgets.plot.plot_widget</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>BaseTable</class>
    <extends>QTableWidget</extends>
-   <header>EVA.widgets.base.base_table</header>
+   <header>EVA.gui.base.base_table</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/EVA/gui/ui_files/trim_gui.py
+++ b/src/EVA/gui/ui_files/trim_gui.py
@@ -289,7 +289,12 @@ class Ui_trim(object):
         self.depth_profile_plot.setEnabled(True)
         self.depth_profile_plot.setObjectName("depth_profile_plot")
         self.depth_profile_layout.addWidget(self.depth_profile_plot)
-        spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem = QtWidgets.QSpacerItem(
+            20,
+            40,
+            QtWidgets.QSizePolicy.Policy.Minimum,
+            QtWidgets.QSizePolicy.Policy.Expanding,
+        )
         self.depth_profile_layout.addItem(spacerItem)
         self.depth_settings_widget = QtWidgets.QWidget(parent=self.depth_profile_tab)
         self.depth_settings_widget.setObjectName("depth_settings_widget")
@@ -340,9 +345,15 @@ class Ui_trim(object):
         item.setText(_translate("trim", "Options"))
         self.save_all_sims_button.setText(_translate("trim", "Save all results"))
         self.save_all_imgs_button.setText(_translate("trim", "Save all plots"))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.results_tab), _translate("trim", "Results"))
-        self.collapse_expand_implantation_checkbox.setText(_translate("trim", " Expand all / Collapse"))
-        self.results_tree.headerItem().setText(0, _translate("trim", "Momentum (MeV/c)"))
+        self.tabWidget.setTabText(
+            self.tabWidget.indexOf(self.results_tab), _translate("trim", "Results")
+        )
+        self.collapse_expand_implantation_checkbox.setText(
+            _translate("trim", " Expand all / Collapse")
+        )
+        self.results_tree.headerItem().setText(
+            0, _translate("trim", "Momentum (MeV/c)")
+        )
         self.results_tree.headerItem().setText(1, _translate("trim", "Layers"))
         self.results_tree.headerItem().setText(
             2, _translate("trim", "% of muons in layer")

--- a/src/EVA/gui/ui_files/trim_gui.py
+++ b/src/EVA/gui/ui_files/trim_gui.py
@@ -165,7 +165,10 @@ class Ui_trim(object):
         self.gridLayout_3.addWidget(self.results_table, 0, 0, 1, 2)
         self.save_all_sims_button = QtWidgets.QPushButton(parent=self.results_tab)
         self.save_all_sims_button.setObjectName("save_all_sims_button")
-        self.gridLayout_3.addWidget(self.save_all_sims_button, 3, 0, 1, 2)
+        self.gridLayout_3.addWidget(self.save_all_sims_button, 4, 0, 1, 2)
+        self.save_all_imgs_button = QtWidgets.QPushButton(parent=self.results_tab)
+        self.save_all_imgs_button.setObjectName("save_all_imgs_button")
+        self.gridLayout_3.addWidget(self.save_all_imgs_button, 3, 0, 1, 2)
         self.tabWidget.addTab(self.results_tab, "")
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")
@@ -286,6 +289,8 @@ class Ui_trim(object):
         self.depth_profile_plot.setEnabled(True)
         self.depth_profile_plot.setObjectName("depth_profile_plot")
         self.depth_profile_layout.addWidget(self.depth_profile_plot)
+        spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        self.depth_profile_layout.addItem(spacerItem)
         self.depth_settings_widget = QtWidgets.QWidget(parent=self.depth_profile_tab)
         self.depth_settings_widget.setObjectName("depth_settings_widget")
         self.depth_profile_layout.addWidget(self.depth_settings_widget)
@@ -295,7 +300,7 @@ class Ui_trim(object):
 
         self.retranslateUi(trim)
         self.tabWidget.setCurrentIndex(0)
-        self.results_tabs.setCurrentIndex(1)
+        self.results_tabs.setCurrentIndex(0)
         QtCore.QMetaObject.connectSlotsByName(trim)
 
     def retranslateUi(self, trim):
@@ -333,16 +338,11 @@ class Ui_trim(object):
         item.setText(_translate("trim", "Momentum (MeV/c)"))
         item = self.results_table.horizontalHeaderItem(1)
         item.setText(_translate("trim", "Options"))
-        self.save_all_sims_button.setText(_translate("trim", "Save all"))
-        self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.results_tab), _translate("trim", "Results")
-        )
-        self.collapse_expand_implantation_checkbox.setText(
-            _translate("trim", " Expand all / Collapse")
-        )
-        self.results_tree.headerItem().setText(
-            0, _translate("trim", "Momentum (MeV/c)")
-        )
+        self.save_all_sims_button.setText(_translate("trim", "Save all results"))
+        self.save_all_imgs_button.setText(_translate("trim", "Save all plots"))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.results_tab), _translate("trim", "Results"))
+        self.collapse_expand_implantation_checkbox.setText(_translate("trim", " Expand all / Collapse"))
+        self.results_tree.headerItem().setText(0, _translate("trim", "Momentum (MeV/c)"))
         self.results_tree.headerItem().setText(1, _translate("trim", "Layers"))
         self.results_tree.headerItem().setText(
             2, _translate("trim", "% of muons in layer")

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -277,10 +277,8 @@ class TrimModel(QObject):
 
         # set all plot origins to be shifted by default so that 0 on the x-axis is located at end of aluminium layer
         self.default_origin_position = self.layer_boundary_positions[3]
-        self.stopping_plot_origin_shifts = np.full(
-            shape=len(self.momentum), fill_value=self.default_origin_position
-        )
-
+        self.stopping_plot_origin_shifts = np.full(shape=len(self.momentum), fill_value=self.default_origin_position)
+        self.depth_plot_origin_shift = self.default_origin_position
         # after sucessful run, update srim installation directory in config
         get_config()["SRIM"]["installation_directory"] = self.srim_exe_dir
         get_config()["SRIM"]["output_directory"] = self.srim_out_dir

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -537,14 +537,8 @@ class TrimModel(QObject):
         for i in range(len(self.sample_layers)):
             pos = self.layer_boundary_positions[i + 1]
 
-            axx.axvline(x=pos - x_shift, color="k", linestyle="--")
-            axx.text(
-                pos - x_shift,
-                y_lim_upper * 0.02,
-                self.sample_names[i],
-                horizontalalignment="left",
-                rotation="vertical",
-            )
+            axx.axvline(x=pos - x_shift, color='k', linestyle='--')
+            axx.text(pos - x_shift, y_lim_upper * 0.02, self.sample_names[i], horizontalalignment='right', rotation='vertical')
 
         return figt, axx
 
@@ -585,14 +579,8 @@ class TrimModel(QObject):
 
             # display layer boundaries
             pos = self.layer_boundary_positions[i + 1]
-            axx.axvline(x=pos - x_shift, color="k", linestyle="--")
-            axx.text(
-                pos - x_shift,
-                y_lim_upper * 0.02,
-                self.sample_names[i],
-                horizontalalignment="left",
-                rotation="vertical",
-            )
+            axx.axvline(x=pos - x_shift, color='k', linestyle='--')
+            axx.text(pos - x_shift, y_lim_upper * 0.02, self.sample_names[i], horizontalalignment='right', rotation='vertical')
 
         axx.legend()
         self.figs[momentum_index] = axx
@@ -655,14 +643,8 @@ class TrimModel(QObject):
 
         for i, boundary in enumerate(boundaries):
             ix = np.where(self.layer_boundary_positions == boundary)[0][0]
-            name = self.sample_names[ix - 1]
-            ax.text(
-                x=closest_momenta[i],
-                y=0.04 * y_lim_upper,
-                s=name,
-                horizontalalignment="left",
-                rotation="vertical",
-            )
+            name = self.sample_names[ix-1]
+            ax.text(x=closest_momenta[i], y=0.04*y_lim_upper, s=name, horizontalalignment='right', rotation='vertical')
 
         ax.set_xlabel("Momentum (MeV/c)")
         ax.set_ylabel("Proportion")

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -137,7 +137,10 @@ class TrimModel(QObject):
                 # insert results into results arrays
                 self.result_x[momentum_index, :] = x
                 self.result_y[momentum_index, :] = y
-                self.result_y[momentum_index, :] = (self.result_y[momentum_index, :] / np.sum(self.result_y[momentum_index, :])) * self.stats
+                self.result_y[momentum_index, :] = (
+                    self.result_y[momentum_index, :]
+                    / np.sum(self.result_y[momentum_index, :])
+                ) * self.stats
                 t1 = time.time_ns()
 
                 dt = (t1 - t0) / 1e9
@@ -175,8 +178,9 @@ class TrimModel(QObject):
                     # Normalise value at point  using probability density function.
                     deltaP = 0.5 * MomSigma
 
-                    pdf = (1.0 / (np.sqrt(2.0 * np.pi) * MomSigma)) \
-                        * np.exp(-0.5 * (P - mom)**2 / MomSigma**2)
+                    pdf = (1.0 / (np.sqrt(2.0 * np.pi) * MomSigma)) * np.exp(
+                        -0.5 * (P - mom) ** 2 / MomSigma**2
+                    )
 
                     NE = round(self.stats * pdf * deltaP)
                     # get muon information
@@ -212,8 +216,16 @@ class TrimModel(QObject):
 
                     # report progress to gui
                     progress_callback.emit(
-                        {"current": simulation_count, "total": total_sims, "sim_times": self.simulation_times})
-                self.result_y[momentum_index, :] = (self.result_y[momentum_index, :] / np.sum(self.result_y[momentum_index, :])) * self.stats
+                        {
+                            "current": simulation_count,
+                            "total": total_sims,
+                            "sim_times": self.simulation_times,
+                        }
+                    )
+                self.result_y[momentum_index, :] = (
+                    self.result_y[momentum_index, :]
+                    / np.sum(self.result_y[momentum_index, :])
+                ) * self.stats
                 print("yres sum after normalising: ", np.sum(yres))
 
         else:
@@ -275,7 +287,9 @@ class TrimModel(QObject):
 
         # set all plot origins to be shifted by default so that 0 on the x-axis is located at end of aluminium layer
         self.default_origin_position = self.layer_boundary_positions[3]
-        self.stopping_plot_origin_shifts = np.full(shape=len(self.momentum), fill_value=self.default_origin_position)
+        self.stopping_plot_origin_shifts = np.full(
+            shape=len(self.momentum), fill_value=self.default_origin_position
+        )
         self.depth_plot_origin_shift = self.default_origin_position
         # after sucessful run, update srim installation directory in config
         get_config()["SRIM"]["installation_directory"] = self.srim_exe_dir
@@ -535,8 +549,14 @@ class TrimModel(QObject):
         for i in range(len(self.sample_layers)):
             pos = self.layer_boundary_positions[i + 1]
 
-            axx.axvline(x=pos - x_shift, color='k', linestyle='--')
-            axx.text(pos - x_shift, y_lim_upper * 0.02, self.sample_names[i], horizontalalignment='right', rotation='vertical')
+            axx.axvline(x=pos - x_shift, color="k", linestyle="--")
+            axx.text(
+                pos - x_shift,
+                y_lim_upper * 0.02,
+                self.sample_names[i],
+                horizontalalignment="right",
+                rotation="vertical",
+            )
 
         return figt, axx
 
@@ -577,8 +597,14 @@ class TrimModel(QObject):
 
             # display layer boundaries
             pos = self.layer_boundary_positions[i + 1]
-            axx.axvline(x=pos - x_shift, color='k', linestyle='--')
-            axx.text(pos - x_shift, y_lim_upper * 0.02, self.sample_names[i], horizontalalignment='right', rotation='vertical')
+            axx.axvline(x=pos - x_shift, color="k", linestyle="--")
+            axx.text(
+                pos - x_shift,
+                y_lim_upper * 0.02,
+                self.sample_names[i],
+                horizontalalignment="right",
+                rotation="vertical",
+            )
 
         axx.legend()
         self.figs[momentum_index] = axx
@@ -641,8 +667,14 @@ class TrimModel(QObject):
 
         for i, boundary in enumerate(boundaries):
             ix = np.where(self.layer_boundary_positions == boundary)[0][0]
-            name = self.sample_names[ix-1]
-            ax.text(x=closest_momenta[i], y=0.04*y_lim_upper, s=name, horizontalalignment='right', rotation='vertical')
+            name = self.sample_names[ix - 1]
+            ax.text(
+                x=closest_momenta[i],
+                y=0.04 * y_lim_upper,
+                s=name,
+                horizontalalignment="right",
+                rotation="vertical",
+            )
 
         ax.set_xlabel("Momentum (MeV/c)")
         ax.set_ylabel("Proportion")
@@ -662,11 +694,16 @@ class TrimModel(QObject):
 
     def get_default_srim_plot_save_name(self, momentum: float | None = None) -> str:
         if momentum is None:
-            return os.path.join(f"{get_config()['general']['working_directory']}", "SRIM_stopping_profile_plots.zip")
+            return os.path.join(
+                f"{get_config()['general']['working_directory']}",
+                "SRIM_stopping_profile_plots.zip",
+            )
         else:
             momentum = f"{momentum:.5f}"
-        return os.path.join(f"{get_config()['general']['working_directory']}", f"SRIM_{momentum}_stopping_profile.png")
-
+        return os.path.join(
+            f"{get_config()['general']['working_directory']}",
+            f"SRIM_{momentum}_stopping_profile.png",
+        )
 
     def save_sim(self, path: str, rows: list | int | None = None):
         if isinstance(rows, int):
@@ -716,11 +753,13 @@ class TrimModel(QObject):
 
     def save_plot(self, path: str, rows: list | int | None = None):
         if isinstance(rows, int):
-            fig = self.figs[rows].figure  # get the matplotlib Figure object from the Axes
-            fig.savefig(path, bbox_inches='tight')  # save the figure
+            fig = self.figs[
+                rows
+            ].figure  # get the matplotlib Figure object from the Axes
+            fig.savefig(path, bbox_inches="tight")  # save the figure
 
         if rows is None:
-            with ZipFile(path, 'w') as zipf:
+            with ZipFile(path, "w") as zipf:
                 for i, momentum_value in enumerate(self.momentum):
                     if i not in self.figs:
                         continue  # skip rows with no plot
@@ -729,7 +768,7 @@ class TrimModel(QObject):
 
                     # Save figure to a bytes buffer
                     buf = io.BytesIO()
-                    fig.savefig(buf, format='png', bbox_inches='tight')
+                    fig.savefig(buf, format="png", bbox_inches="tight")
                     buf.seek(0)
 
                     # Use a descriptive filename inside the zip
@@ -737,9 +776,22 @@ class TrimModel(QObject):
                     zipf.writestr(filename, buf.read())
                     buf.close()
 
-    def save_settings(self, sample_name, stats, srim_dir, output_dir, momentum, momentum_spread, sim_type,
-                        min_momentum, max_momentum, step_momentum, scan_type, layers, target_dir):
-
+    def save_settings(
+        self,
+        sample_name,
+        stats,
+        srim_dir,
+        output_dir,
+        momentum,
+        momentum_spread,
+        sim_type,
+        min_momentum,
+        max_momentum,
+        step_momentum,
+        scan_type,
+        layers,
+        target_dir,
+    ):
         file2 = open(target_dir, "w")
         file2.writelines("Sample Name\n")
         out = sample_name + "\n"

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -162,7 +162,7 @@ class TrimModel(QObject):
                 MomSigma = 0.01 * self.momentum_spread * mom
 
                 xres, yres = [], []
-
+                total_counter = 0
                 for i in range(self.sigma_step + 1):
                     t0 = time.time_ns()
 
@@ -171,12 +171,12 @@ class TrimModel(QObject):
                     )  # momentum for each iteration
 
                     # Number of simulated muons dependent on Gaussian distribution of muon momentum
-                    NE = int(
-                        self.stats
-                        * (1.0 / (np.sqrt(2.0 * np.pi) * MomSigma))
-                        * np.exp(-0.5 * (P - mom) ** 2 / (MomSigma**2))
-                    )
+                    deltaP = 0.5 * MomSigma
 
+                    pdf = (1.0 / (np.sqrt(2.0 * np.pi) * MomSigma)) \
+                        * np.exp(-0.5 * (P - mom)**2 / MomSigma**2)
+
+                    NE = round(self.stats * pdf * deltaP)
                     # get muon information
                     muon_ion = self.get_muon(P)
 
@@ -195,7 +195,10 @@ class TrimModel(QObject):
                     else:
                         for index in range(0, len(y1)):
                             yres[index] = yres[index] + y1[index]
-
+                    total_counter += NE
+                    print("num_events in current slice: ", NE)
+                    print("total muons so far: ", total_counter)
+                    print("yres sum: ", np.sum(yres))
                     # insert results into results arrays
                     self.result_x[momentum_index, :] = xres
                     self.result_y[momentum_index, :] = yres

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -171,7 +171,8 @@ class TrimModel(QObject):
                         mom - 3 * MomSigma + i * 0.5 * MomSigma
                     )  # momentum for each iteration
 
-                    # Number of simulated muons dependent on Gaussian distribution of muon momentum
+                    # Calculate number of muons to simulate for current momentum using normal distribution
+                    # Normalise value at point  using probability density function.
                     deltaP = 0.5 * MomSigma
 
                     pdf = (1.0 / (np.sqrt(2.0 * np.pi) * MomSigma)) \
@@ -197,9 +198,6 @@ class TrimModel(QObject):
                         for index in range(0, len(y1)):
                             yres[index] = yres[index] + y1[index]
                     total_counter += NE
-                    print("num_events in current slice: ", NE)
-                    print("total muons so far: ", total_counter)
-                    print("yres sum: ", np.sum(yres))
 
                     # normalise the y
                     # insert results into results arrays

--- a/src/EVA/gui/windows/srim/trim_model.py
+++ b/src/EVA/gui/windows/srim/trim_model.py
@@ -1,4 +1,5 @@
 import os
+import io
 import time
 from zipfile import ZipFile
 
@@ -57,7 +58,7 @@ class TrimModel(QObject):
         self.counts_per_layer_err = None
         self.proportions_per_layer = None
         self.proportions_per_layer_err = None
-
+        self.figs = {}
         # for storing an x-axis shift for each momentum plot (one for each momentum)
         self.default_origin_position = 0
         self.stopping_plot_origin_shifts = []
@@ -136,7 +137,7 @@ class TrimModel(QObject):
                 # insert results into results arrays
                 self.result_x[momentum_index, :] = x
                 self.result_y[momentum_index, :] = y
-
+                self.result_y[momentum_index, :] = (self.result_y[momentum_index, :] / np.sum(self.result_y[momentum_index, :])) * self.stats
                 t1 = time.time_ns()
 
                 dt = (t1 - t0) / 1e9
@@ -199,6 +200,8 @@ class TrimModel(QObject):
                     print("num_events in current slice: ", NE)
                     print("total muons so far: ", total_counter)
                     print("yres sum: ", np.sum(yres))
+
+                    # normalise the y
                     # insert results into results arrays
                     self.result_x[momentum_index, :] = xres
                     self.result_y[momentum_index, :] = yres
@@ -211,12 +214,9 @@ class TrimModel(QObject):
 
                     # report progress to gui
                     progress_callback.emit(
-                        {
-                            "current": simulation_count,
-                            "total": total_sims,
-                            "sim_times": self.simulation_times,
-                        }
-                    )
+                        {"current": simulation_count, "total": total_sims, "sim_times": self.simulation_times})
+                self.result_y[momentum_index, :] = (self.result_y[momentum_index, :] / np.sum(self.result_y[momentum_index, :])) * self.stats
+                print("yres sum after normalising: ", np.sum(yres))
 
         else:
             raise ValueError("Invalid simulation type specified")
@@ -597,7 +597,7 @@ class TrimModel(QObject):
             )
 
         axx.legend()
-
+        self.figs[momentum_index] = axx
         return figt, axx
 
     def plot_depth_profile(self) -> tuple[plt.Figure, plt.Axes]:
@@ -682,6 +682,14 @@ class TrimModel(QObject):
             f"SRIM_{momentum}_MeVc.zip",
         )
 
+    def get_default_srim_plot_save_name(self, momentum: float | None = None) -> str:
+        if momentum is None:
+            return os.path.join(f"{get_config()['general']['working_directory']}", "SRIM_stopping_profile_plots.zip")
+        else:
+            momentum = f"{momentum:.5f}"
+        return os.path.join(f"{get_config()['general']['working_directory']}", f"SRIM_{momentum}_stopping_profile.png")
+
+
     def save_sim(self, path: str, rows: list | int | None = None):
         if isinstance(rows, int):
             rows = [rows]
@@ -728,22 +736,32 @@ class TrimModel(QObject):
 
                     zf.writestr(layer_filename, layer_curve_str)
 
-    def save_settings(
-        self,
-        sample_name,
-        stats,
-        srim_dir,
-        output_dir,
-        momentum,
-        momentum_spread,
-        sim_type,
-        min_momentum,
-        max_momentum,
-        step_momentum,
-        scan_type,
-        layers,
-        target_dir,
-    ):
+    def save_plot(self, path: str, rows: list | int | None = None):
+        if isinstance(rows, int):
+            fig = self.figs[rows].figure  # get the matplotlib Figure object from the Axes
+            fig.savefig(path, bbox_inches='tight')  # save the figure
+
+        if rows is None:
+            with ZipFile(path, 'w') as zipf:
+                for i, momentum_value in enumerate(self.momentum):
+                    if i not in self.figs:
+                        continue  # skip rows with no plot
+
+                    fig = self.figs[i].figure
+
+                    # Save figure to a bytes buffer
+                    buf = io.BytesIO()
+                    fig.savefig(buf, format='png', bbox_inches='tight')
+                    buf.seek(0)
+
+                    # Use a descriptive filename inside the zip
+                    filename = f"SRIM_plot_momentum_{momentum_value:.1f}.png"
+                    zipf.writestr(filename, buf.read())
+                    buf.close()
+
+    def save_settings(self, sample_name, stats, srim_dir, output_dir, momentum, momentum_spread, sim_type,
+                        min_momentum, max_momentum, step_momentum, scan_type, layers, target_dir):
+
         file2 = open(target_dir, "w")
         file2.writelines("Sample Name\n")
         out = sample_name + "\n"

--- a/src/EVA/gui/windows/srim/trim_presenter.py
+++ b/src/EVA/gui/windows/srim/trim_presenter.py
@@ -67,8 +67,10 @@ class TrimPresenter(QWidget):
         self.view.depth_shift_plot_origin_s.connect(self.depth_shift_plot_origin)
         self.view.depth_reset_plot_origin_s.connect(self.depth_reset_plot_origin)
 
-        self.view.save_s.connect(self.on_save_sim_result)
+        self.view.save_data_s.connect(self.on_save_sim_result)
+        self.view.save_img_s.connect(self.on_save_sim_plot)
         self.view.save_all_sims_button.clicked.connect(self.on_save_all_sim_results)
+        self.view.save_all_imgs_button.clicked.connect(self.on_save_all_sim_plot)
         self.view.show_plot_s.connect(self.show_plot)
         self.view.momentum_slider.valueChanged.connect(self.on_slider_moved)
 
@@ -439,7 +441,7 @@ class TrimPresenter(QWidget):
             self.model.save_sim(path, row)
 
     def on_save_all_sim_results(self):
-        if len(self.model.result_x) == 0:  # if no simulations have been run
+        if not self.model.result_x: # if no simulations have been run
             self.view.display_error_message(message="No simulations to save.")
             return
 
@@ -451,6 +453,37 @@ class TrimPresenter(QWidget):
         if path:
             self.model.save_sim(path)
 
+    def on_save_sim_plot(self, row):
+        # check if the figure for this momentum exists
+        if row not in self.model.figs:
+            self.view.display_error_message(message="No plots available to save.")
+            return
+
+        # default filename
+        default_path = self.model.get_default_srim_plot_save_name(self.model.momentum[row])
+        filter_str = "PNG Image (*.png);;PDF File (*.pdf);;All Files (*)"
+
+        # get path from user
+        path = self.view.get_save_file_path(default_path, filter_str)
+
+        if path:
+            self.model.save_plot(path, row)
+
+    def on_save_all_sim_plot(self):
+        # check if the figure for this momentum exists
+        if not self.model.figs:
+            self.view.display_error_message(message="No plots available to save.")
+            return
+
+        # default filename
+        default_path = self.model.get_default_srim_plot_save_name()
+        filter_str = "Zip Archive (*.zip)"
+
+        # get path from user
+        path = self.view.get_save_file_path(default_path, filter_str)
+
+        if path:
+            self.model.save_plot(path)
     def save_settings(self):
         try:
             form_data = self.view.get_form_data()

--- a/src/EVA/gui/windows/srim/trim_presenter.py
+++ b/src/EVA/gui/windows/srim/trim_presenter.py
@@ -441,7 +441,7 @@ class TrimPresenter(QWidget):
             self.model.save_sim(path, row)
 
     def on_save_all_sim_results(self):
-        if not self.model.result_x: # if no simulations have been run
+        if not self.model.result_x:  # if no simulations have been run
             self.view.display_error_message(message="No simulations to save.")
             return
 
@@ -460,7 +460,9 @@ class TrimPresenter(QWidget):
             return
 
         # default filename
-        default_path = self.model.get_default_srim_plot_save_name(self.model.momentum[row])
+        default_path = self.model.get_default_srim_plot_save_name(
+            self.model.momentum[row]
+        )
         filter_str = "PNG Image (*.png);;PDF File (*.pdf);;All Files (*)"
 
         # get path from user
@@ -484,6 +486,7 @@ class TrimPresenter(QWidget):
 
         if path:
             self.model.save_plot(path)
+
     def save_settings(self):
         try:
             form_data = self.view.get_form_data()

--- a/src/EVA/gui/windows/srim/trim_presenter.py
+++ b/src/EVA/gui/windows/srim/trim_presenter.py
@@ -188,7 +188,7 @@ class TrimPresenter(QWidget):
 
     def depth_reset_plot_origin(self):
         try:
-            self.model.depth_plot_origin_shift = 0
+            self.model.depth_plot_origin_shift = self.model.default_origin_position
             self.view.depth_shift_origin_linedit.setText("0")
             fig, ax = self.model.plot_depth_profile()
 

--- a/src/EVA/gui/windows/srim/trim_view.py
+++ b/src/EVA/gui/windows/srim/trim_view.py
@@ -96,10 +96,10 @@ class TrimView(BaseView, Ui_trim):
             plot_whole_btn.setText("Show plot")
 
             save_data_btn = QPushButton()
-            save_data_btn.setText('Save plot data')
+            save_data_btn.setText("Save plot data")
 
             save_plot_img_btn = QPushButton()
-            save_plot_img_btn.setText('Save plot image')
+            save_plot_img_btn.setText("Save plot image")
 
             layout.addWidget(plot_whole_btn)
             layout.addWidget(save_data_btn)
@@ -111,11 +111,9 @@ class TrimView(BaseView, Ui_trim):
                 lambda _, r=row, m=momentumstr: self.show_plot_s.emit(r, m)
             )
 
-            save_data_btn.clicked.connect(
-                lambda _, r=row: self.save_data_s.emit(r))
-            
-            save_plot_img_btn.clicked.connect(
-                lambda _, r=row: self.save_img_s.emit(r))
+            save_data_btn.clicked.connect(lambda _, r=row: self.save_data_s.emit(r))
+
+            save_plot_img_btn.clicked.connect(lambda _, r=row: self.save_img_s.emit(r))
 
     def update_results_tree(
         self, momenta, layer_names, proportions, proportions_errs, counts, counts_errs

--- a/src/EVA/gui/windows/srim/trim_view.py
+++ b/src/EVA/gui/windows/srim/trim_view.py
@@ -30,7 +30,9 @@ class TrimView(BaseView, Ui_trim):
     save_plot_requested_s = pyqtSignal(int, str)
 
     show_plot_s = pyqtSignal(int, str)
-    save_s = pyqtSignal(int)
+    save_data_s = pyqtSignal(int)
+    save_img_s = pyqtSignal(int)
+
     depth_shift_plot_origin_s = pyqtSignal()
     depth_reset_plot_origin_s = pyqtSignal()
     stopping_shift_plot_origin_s = pyqtSignal(int)
@@ -93,11 +95,15 @@ class TrimView(BaseView, Ui_trim):
             plot_whole_btn = QPushButton()
             plot_whole_btn.setText("Show plot")
 
-            save_btn = QPushButton()
-            save_btn.setText("Save plot data")
+            save_data_btn = QPushButton()
+            save_data_btn.setText('Save plot data')
+
+            save_plot_img_btn = QPushButton()
+            save_plot_img_btn.setText('Save plot image')
 
             layout.addWidget(plot_whole_btn)
-            layout.addWidget(save_btn)
+            layout.addWidget(save_data_btn)
+            layout.addWidget(save_plot_img_btn)
 
             table.setCellWidget(row, 1, options_container)
 
@@ -105,7 +111,11 @@ class TrimView(BaseView, Ui_trim):
                 lambda _, r=row, m=momentumstr: self.show_plot_s.emit(r, m)
             )
 
-            save_btn.clicked.connect(lambda _, r=row: self.save_s.emit(r))
+            save_data_btn.clicked.connect(
+                lambda _, r=row: self.save_data_s.emit(r))
+            
+            save_plot_img_btn.clicked.connect(
+                lambda _, r=row: self.save_img_s.emit(r))
 
     def update_results_tree(
         self, momenta, layer_names, proportions, proportions_errs, counts, counts_errs

--- a/tests/gui/test_plot_window.py
+++ b/tests/gui/test_plot_window.py
@@ -150,7 +150,10 @@ class TestPlotWindow:
         )
 
     @pytest.mark.parametrize("tests", muon_plot_lines_tests)
-    @pytest.mark.skipif(True, reason="Temporarily disabled until issue with missing mudirac intensities is fixed")
+    @pytest.mark.skipif(
+        True,
+        reason="Temporarily disabled until issue with missing mudirac intensities is fixed",
+    )
     def test_plot_and_remove_lines_muonic_xrays(self, qtbot, tests):
         # first element in tuple is which energy to search, second element in tuple is how many lines will be plotted
         # when clicking the first element in the table after searching that energy.

--- a/tests/system/test_model_spectra.py
+++ b/tests/system/test_model_spectra.py
@@ -147,7 +147,10 @@ class TestModelSpectrumModel:
             assert np.array_equal(spectrum.y, ydata), "Incorrect ydata plotted"
 
     @pytest.mark.parametrize("notation", [0, 1, 2])
-    @pytest.mark.skipif(True, reason="Temporarily disabled until issue with missing mudirac intensities is fixed")
+    @pytest.mark.skipif(
+        True,
+        reason="Temporarily disabled until issue with missing mudirac intensities is fixed",
+    )
     # This test currently always fails as it tries to compare lines in the previous mu_xray_db and the current extended one.
     def test_plot_components(self, notation):
         test = base_test.copy()


### PR DESCRIPTION
Adds gaussian probability distribution function logic to number of muons calculation when momentum has spread. Fixes #64

 Adds a default origin shift value (equal to start of layer 3) in depth profile plot similar to stopping profile plot.

Changes layer name label alignment from left to right of the vertical lines in result plots.

Adds save individual/all plots options in trim results menu.

 