### PR TITLE
Avoid adding reference to navbar during init

### DIFF
--- a/src/EVA/gui/widgets/plot/plot_widget.py
+++ b/src/EVA/gui/widgets/plot/plot_widget.py
@@ -31,20 +31,19 @@ class PlotWidget(QWidget):
         self, fig=None, axs=None, parent=None, plot_name=None, plot_manager=None
     ):
         super().__init__()
+        self.layout = QVBoxLayout(self)
         # create the figure canvas
         self.canvas = FigureCanvas(fig=fig, axs=axs)
         self.plot_manager = plot_manager
         self.plot_name = plot_name
-
+        # add navbar and plot canvas to layout
         # this avoids having a navbar when there is no figure
         if fig is None:
             self.navbar = None
         else:
             self.navbar = NavigationToolbar2QT(self.canvas, self)
-
+            self.layout.addWidget(self.navbar, Qt.AlignmentFlag.AlignLeft)
         # add navbar and plot canvas to layout
-        self.layout = QVBoxLayout(self)
-        self.layout.addWidget(self.navbar, Qt.AlignmentFlag.AlignLeft)
         self.layout.addWidget(self.canvas)
         self.setLayout(self.layout)
 


### PR DESCRIPTION
Fixes conflict between logic to avoid creating a navbar when there are no plots, and trying to always add a navbar during PlotWidget init by removing attempt to add navbar during init. Update plot, which creates a navbar, to be called after fig has been generated.